### PR TITLE
Fix size of retina settings icon for user menu

### DIFF
--- a/static/css/piskel-app.css
+++ b/static/css/piskel-app.css
@@ -476,6 +476,7 @@ ul {
   }
 
   .user-menu-settings {
+    background-size: 16px;
     background-image:url('/static/resources/settings-icon@2x.png');
   }
 


### PR DESCRIPTION
Just a tiny fix for retina devices! The settings icon is currently too small, and this fixes that by following the patterns you've already established.

Love the app! 😄 

![image](https://user-images.githubusercontent.com/1660908/50381279-b5dbbe80-0648-11e9-81e9-b44ad7875caf.png)
