### PR TITLE
🔥 Remove account mention on download page

### DIFF
--- a/templates/download/download.html
+++ b/templates/download/download.html
@@ -71,7 +71,6 @@
     <div class="download-sub-section">
       <div>Cons</div>
       <ul class="download-about-items">
-        <li class="download-about-item">not connected to your piskelapp.com account</li>
         <li class="download-about-item">performance is usually better with the online version</li>
         <li class="download-about-item">limited testing and quality assurance</li>
       </ul>


### PR DESCRIPTION
Piskel accounts dont exist anymore, so this is pretty useless.